### PR TITLE
HP-15/Ticket-15

### DIFF
--- a/unpackaged/main/default/objects/Account/fields/Churn_Risk__c.field-meta.xml
+++ b/unpackaged/main/default/objects/Account/fields/Churn_Risk__c.field-meta.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
-    <fullName>Churn_Risk__c</fullName>
-    <defaultValue>false</defaultValue>
-    <externalId>false</externalId>
-    <label>Churn Risk</label>
-    <trackFeedHistory>false</trackFeedHistory>
-    <type>Checkbox</type>
-</CustomField>

--- a/unpackaged/main/default/objects/Account/fields/Churn_Risk__c.field-meta.xml
+++ b/unpackaged/main/default/objects/Account/fields/Churn_Risk__c.field-meta.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Churn_Risk__c</fullName>
+    <defaultValue>false</defaultValue>
+    <externalId>false</externalId>
+    <label>Churn Risk</label>
+    <trackFeedHistory>false</trackFeedHistory>
+    <type>Checkbox</type>
+</CustomField>

--- a/unpackaged/main/default/objects/Account/fields/Subscription_number__c.field-meta.xml
+++ b/unpackaged/main/default/objects/Account/fields/Subscription_number__c.field-meta.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Subscription_number__c</fullName>
+    <displayFormat>GEA-{0000000}</displayFormat>
+    <externalId>false</externalId>
+    <label>Subscription number</label>
+    <type>AutoNumber</type>
+</CustomField>

--- a/unpackaged/main/default/objects/Account/fields/Subscription_number_for_Invoice__c.field-meta.xml
+++ b/unpackaged/main/default/objects/Account/fields/Subscription_number_for_Invoice__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Subscription_number_for_Invoice__c</fullName>
+    <externalId>false</externalId>
+    <label>Subscription number for Invoice</label>
+    <length>255</length>
+    <required>false</required>
+    <trackFeedHistory>false</trackFeedHistory>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/unpackaged/main/default/standardValueSets/Salutation.standardValueSet-meta.xml
+++ b/unpackaged/main/default/standardValueSets/Salutation.standardValueSet-meta.xml
@@ -26,4 +26,9 @@
         <default>false</default>
         <label>Prof.</label>
     </standardValue>
+    <standardValue>
+        <fullName>Mx.</fullName>
+        <default>false</default>
+        <label>Mx.</label>
+    </standardValue>
 </StandardValueSet>


### PR DESCRIPTION
## What has changed?
- **Field Modifications:**
 - Deleted the field Churn_Risk__c from the Account object.
 - Updated the SLASerialNumber__c field to change its length from 10 to 5 and added a description.
- **New Fields Added:**
 - Introduced Subscription_number__c as an AutoNumber field with a specific display format.
 - Added Subscription_number_for_Invoice__c as a Text field with a length of 255.
- **Standard Value Set Update:**
 - Added a new salutation option Mx. to the Salutation standard value set.

## What's the impact of these changes?
- **Functional Impact:**
 - Removal of Churn_Risk__c may affect existing reports and integrations.
 - New fields enhance data capture capabilities for subscriptions.

- **Potential Downstream Impacts:**
 - Adjustments may be needed in any automation or validation rules referencing the deleted field.

## What should reviewers pay attention to?
- Review the implications of deleting Churn_Risk__c on existing data and processes.
- Ensure that the new fields are correctly integrated into existing workflows and UI.

## Testing recommendations
- **Manual Testing:** Validate that the new fields function as expected in the UI and reports.
- **Regression Testing:** Check for any broken references or errors in automation related to the deleted field.
- **Unit Tests:**
* No unit tests changed.